### PR TITLE
cmake: set install name and rpath on OSX, add Log4cpp to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,10 +81,31 @@ set(GR_PKG_LIBEXEC_DIR  ${GR_LIBEXEC_DIR}/${CMAKE_PROJECT_NAME})
 set(GRC_BLOCKS_DIR      ${GR_PKG_DATA_DIR}/grc/blocks)
 
 ########################################################################
+# On Apple only, set install name and use rpath correctly, if not already set
+########################################################################
+if(APPLE)
+   if(NOT CMAKE_INSTALL_NAME_DIR)
+       set(CMAKE_INSTALL_NAME_DIR
+           ${CMAKE_INSTALL_PREFIX}/${GR_LIBRARY_DIR} CACHE
+           PATH "Library Install Name Destination Directory" FORCE)
+   endif(NOT CMAKE_INSTALL_NAME_DIR)
+   if(NOT CMAKE_INSTALL_RPATH)
+       set(CMAKE_INSTALL_RPATH
+           ${CMAKE_INSTALL_PREFIX}/${GR_LIBRARY_DIR} CACHE
+           PATH "Library Install RPath" FORCE)
+   endif(NOT CMAKE_INSTALL_RPATH)
+   if(NOT CMAKE_BUILD_WITH_INSTALL_RPATH)
+       set(CMAKE_BUILD_WITH_INSTALL_RPATH ON CACHE
+           BOOL "Do Build Using Library Install RPath" FORCE)
+   endif(NOT CMAKE_BUILD_WITH_INSTALL_RPATH)
+endif(APPLE)
+
+########################################################################
 # Find gnuradio build dependencies
 ########################################################################
 find_package(CppUnit)
 find_package(Doxygen)
+find_package(Log4cpp)
 
 # Search for GNU Radio and its components and versions. Add any
 # components required to the list of GR_REQUIRED_COMPONENTS (in all
@@ -116,12 +137,14 @@ include_directories(
     ${CMAKE_BINARY_DIR}/include
     ${Boost_INCLUDE_DIRS}
     ${CPPUNIT_INCLUDE_DIRS}
+    ${LOG4CPP_INCLUDE_DIRS}
     ${GNURADIO_ALL_INCLUDE_DIRS}
 )
 
 link_directories(
     ${Boost_LIBRARY_DIRS}
     ${CPPUNIT_LIBRARY_DIRS}
+    ${LOG4CPP_LIBRARY_DIRS}
     ${GNURADIO_RUNTIME_LIBRARY_DIRS}
 )
 
@@ -158,6 +181,10 @@ add_subdirectory(examples)
 ########################################################################
 # Install cmake search helper for this library
 ########################################################################
+if(NOT CMAKE_MODULES_DIR)
+  set(CMAKE_MODULES_DIR lib${LIB_SUFFIX}/cmake)
+endif(NOT CMAKE_MODULES_DIR)
+
 install(FILES cmake/Modules/tutorialConfig.cmake
-    DESTINATION lib/cmake/tutorial
+    DESTINATION ${CMAKE_MODULES_DIR}/gnuradio/tutorial
 )

--- a/cmake/Modules/FindLog4cpp.cmake
+++ b/cmake/Modules/FindLog4cpp.cmake
@@ -1,0 +1,53 @@
+# - Find Log4cpp
+# Find the native LOG4CPP includes and library
+#
+#  LOG4CPP_INCLUDE_DIR - where to find LOG4CPP.h, etc.
+#  LOG4CPP_LIBRARIES   - List of libraries when using LOG4CPP.
+#  LOG4CPP_FOUND       - True if LOG4CPP found.
+
+
+if (LOG4CPP_INCLUDE_DIR)
+  # Already in cache, be silent
+  set(LOG4CPP_FIND_QUIETLY TRUE)
+endif ()
+
+find_path(LOG4CPP_INCLUDE_DIR log4cpp/Category.hh
+  /opt/local/include
+  /usr/local/include
+  /usr/include
+)
+
+set(LOG4CPP_NAMES log4cpp)
+find_library(LOG4CPP_LIBRARY
+  NAMES ${LOG4CPP_NAMES}
+  PATHS /usr/lib /usr/local/lib /opt/local/lib
+)
+
+
+if (LOG4CPP_INCLUDE_DIR AND LOG4CPP_LIBRARY)
+  set(LOG4CPP_FOUND TRUE)
+  set(LOG4CPP_LIBRARIES ${LOG4CPP_LIBRARY} CACHE INTERNAL "" FORCE)
+  set(LOG4CPP_INCLUDE_DIRS ${LOG4CPP_INCLUDE_DIR} CACHE INTERNAL "" FORCE)
+else ()
+  set(LOG4CPP_FOUND FALSE CACHE INTERNAL "" FORCE)
+  set(LOG4CPP_LIBRARY "" CACHE INTERNAL "" FORCE)
+  set(LOG4CPP_LIBRARIES "" CACHE INTERNAL "" FORCE)
+  set(LOG4CPP_INCLUDE_DIR "" CACHE INTERNAL "" FORCE)
+  set(LOG4CPP_INCLUDE_DIRS "" CACHE INTERNAL "" FORCE)
+endif ()
+
+if (LOG4CPP_FOUND)
+  if (NOT LOG4CPP_FIND_QUIETLY)
+    message(STATUS "Found LOG4CPP: ${LOG4CPP_LIBRARIES}")
+  endif ()
+else ()
+  if (LOG4CPP_FIND_REQUIRED)
+    message(STATUS "Looked for LOG4CPP libraries named ${LOG4CPPS_NAMES}.")
+    message(FATAL_ERROR "Could NOT find LOG4CPP library")
+  endif ()
+endif ()
+
+mark_as_advanced(
+  LOG4CPP_LIBRARIES
+  LOG4CPP_INCLUDE_DIRS
+)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -37,7 +37,7 @@ if(NOT tutorial_sources)
 endif(NOT tutorial_sources)
 
 add_library(gnuradio-tutorial SHARED ${tutorial_sources})
-target_link_libraries(gnuradio-tutorial ${Boost_LIBRARIES} ${GNURADIO_ALL_LIBRARIES})
+target_link_libraries(gnuradio-tutorial ${Boost_LIBRARIES} ${LOG4CPP_LIBRARIES} ${GNURADIO_ALL_LIBRARIES})
 set_target_properties(gnuradio-tutorial PROPERTIES DEFINE_SYMBOL "gnuradio_tutorial_EXPORTS")
 
 if(APPLE)


### PR DESCRIPTION
This commit updates gr-tutorial to work on OSX with a macports install of gnruadio. 
